### PR TITLE
Fixed "object has no method replace" error

### DIFF
--- a/src/whip.coffee
+++ b/src/whip.coffee
@@ -70,10 +70,11 @@ tokenize = (input) ->
     .join('"')
     .trim()
     .split(/\s+/)
-    .map (x) -> x
-      .replace(/!space!/g, " ")
-      .replace(/!dquote!/g, '\\"')
-      .replace(/!squote!/g, "\\'")
+    .map (x) ->
+      x
+        .replace(/!space!/g, " ")
+        .replace(/!dquote!/g, '\\"')
+        .replace(/!squote!/g, "\\'")
   i = 1
   for t in o[1..]
     switch t


### PR DESCRIPTION
Broken indentation was making it throw an error

*P.S.: Don't merge yet. I found another issue when replacing in the current way. I'm gonna try to fix it before.
